### PR TITLE
Removing forced UTF-8 Encoding

### DIFF
--- a/tosca_execution_client.ps1
+++ b/tosca_execution_client.ps1
@@ -258,8 +258,7 @@ function writeResults([bool]$writePartialResults = $false) {
         }
 
         try {
-            $Utf8Encoding = New-Object System.Text.UTF8Encoding $False
-            [System.IO.File]::WriteAllLines($resultsFilePath, $executionResults, $Utf8Encoding)
+            [System.IO.File]::WriteAllLines($resultsFilePath, $executionResults)
             log "INF" "Finished writing execution results to file ""$resultsFilePath""."
 
         } catch {


### PR DESCRIPTION
Removing forced UTF-8 encoding while writing JUnit results as this has lead to files being generated with encoding UTF-16 LE BOM on some systems.
According to https://learn.microsoft.com/en-us/dotnet/api/system.io.file.writealllines?view=net-7.0 File.WriteAllLines uses UTF-8 encoding by default