### PR TITLE
Execution client ps encoding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use Tosca Execution Clients, you need Tosca Server 15.2 LTS or higher. We off
   * You need PowerShell 3.1 or newer.
 * Linux
   * The client is available as Shell script.
-  * You need curl 7.12.3 or newer.
+  * You need curl 7.43 or newer.
 
 ## Get started
 Depending on whether you want to run the Tosca Execution Client on Windows or Linux, you need different system configurations.

--- a/tosca_execution_client.ps1
+++ b/tosca_execution_client.ps1
@@ -258,8 +258,7 @@ function writeResults([bool]$writePartialResults = $false) {
         }
 
         try {
-            $Utf8Encoding = New-Object System.Text.UTF8Encoding $False
-            [System.IO.File]::WriteAllLines($resultsFilePath, $executionResults, $Utf8Encoding)
+            [System.IO.File]::WriteAllLines($resultsFilePath, $executionResults)
             log "INF" "Finished writing execution results to file ""$resultsFilePath""."
 
         } catch {


### PR DESCRIPTION
Removing forced UTF-8 encoding while writing JUnit results as this has lead to files being generated with encoding UTF-16 LE BOM on some systems.
According to https://learn.microsoft.com/en-us/dotnet/api/system.io.file.writealllines?view=net-7.0 File.WriteAllLines uses UTF-8 encoding by default