### PR TITLE
Fix problem with executionLogs containing special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use Tosca Execution Clients, you need Tosca Server 15.2 LTS or higher. We off
   * You need PowerShell 3.1 or newer.
 * Linux
   * The client is available as Shell script.
-  * You need curl 7.12.3 or newer.
+  * You need curl 7.43 or newer.
 
 ## Get started
 Depending on whether you want to run the Tosca Execution Client on Windows or Linux, you need different system configurations.

--- a/tosca_execution_client.sh
+++ b/tosca_execution_client.sh
@@ -580,7 +580,7 @@ function writeResults() {
       fi
     fi
 
-    echo -e ${executionResults} > ${resultsFilePath} 2> >(logErrorsFromStdIn)
+    echo -E ${executionResults} > ${resultsFilePath} 2> >(logErrorsFromStdIn)
    log "INF" "Finished writing execution results to file \"${resultsFilePath}\""
   fi
 }


### PR DESCRIPTION
Disabling special character interpretation for JUnit results to fix a problem with executionsLogs containing strings like "\v" (e.g.: "Started 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' ") which would generate an invalid JUnit result.