### PR TITLE
fix description for events parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To launch the Tosca Execution Client on a Linux system, use the following comman
 | :-------------------- | :------------ 
 | toscaServerUrl        | URL of Tosca Server, e.g. https://myserver.tricentis.com or http://111.111.111.0:81. 
 | projectName           | Project root name of the Tosca project where the event is located.      
-| events                | Names or uniqueIds of the events that you want to execute, separated by comma. If you want to overwrite TCPs or Agent Characteristics for a specific event, use the "eventsConfigFilePath" parameter instead.      
+| events                | Stringified JSON array containing the names or uniqueIds of the events that you want to execute. If you want to overwrite TCPs or Agent Characteristics for a specific event, use the "eventsConfigFilePath" parameter instead.
 | eventsConfigFilePath &nbsp; &nbsp;  | Path to the JSON file that contains the event configuration, including TCPs and Agent Characteristics. If you use this parameter, you don't need to use the "events" parameter.
 
 Check out the [Tosca help](https://support.tricentis.com/community/manuals_detail.do?&url=continuous_integration/tosca_execution_clients.htm) for more information on how to configure events and some practical examples.

--- a/tosca_execution_client.ps1
+++ b/tosca_execution_client.ps1
@@ -72,7 +72,7 @@ function displayHelp() {
     Write-Output "Mandatory parameters:"
     Write-Output " toscaServerUrl            URL of Tosca Server, e.g. https://myserver.tricentis.com or http://111.111.111.0:81."
     Write-Output " projectName               Project root name of the Tosca project where the event is located."
-    Write-Output " events                    Names or uniqueIds of the events that you want to execute, separated by comma. If you want to overwrite TCPs or Agent Characteristics for a specific event, use the ""eventsConfigFilePath"" parameter instead."
+    Write-Output " events                    Stringified JSON array containing the names or uniqueIds of the events that you want to execute. If you want to overwrite TCPs or Agent Characteristics for a specific event, use the ""eventsConfigFilePath"" parameter instead."
     Write-Output " eventsConfigFilePath      Path to the JSON file that contains the event configuration, including TCPs and Agent Characteristics. If you use this parameter, you don't need to use the ""events"" parameter."
 
     Write-Output "`nOptions:"

--- a/tosca_execution_client.sh
+++ b/tosca_execution_client.sh
@@ -92,7 +92,7 @@ function displayHelp() {
   echo " Mandatory parameters:"
   echo "  --toscaServerUrl        URL of Tosca Server, e.g. https://myserver.tricentis.com or http://111.111.111.0:81."
   echo "  --projectName           Project root name of the Tosca project where the event is located."
-  echo "  --events                Names or uniqueIds of the events that you want to execute, separated by comma. If you want to overwrite TCPs or Agent Characteristics for a specific event, use the \"eventsConfigFilePath\" parameter instead."
+  echo "  --events                Stringified JSON array containing the names or uniqueIds of the events that you want to execute. If you want to overwrite TCPs or Agent Characteristics for a specific event, use the \"eventsConfigFilePath\" parameter instead."
   echo "  --eventsConfigFilePath  Path to the JSON file that contains the event configuration, including TCPs and Agent Characteristics. If you use this parameter, you don't need to use the \"events\" parameter."
   echo -e "\n Options:"
   echo "  --caCertificate         Path to the CA certificate (in PEM format) that the ToscaExecutionClient uses for peer certificate validation. This parameter is mandatory if you use HTTPS and don't use the \"insecure\" parameter."


### PR DESCRIPTION
Fixes #10 

As described in #10 the current event parameter description indicates that the event parameter is a comma separated list of names or unique ids when in reality it is a stringified json array containing those values. This PR fixes the documentation in both scripts as well as in the README itself.