### PR TITLE
Fix exit code when executionStatus Error or Cancel

### DIFF
--- a/tosca_execution_client.sh
+++ b/tosca_execution_client.sh
@@ -721,7 +721,7 @@ do
 done
 
 # Check for execution status after results polling
-if ( [[ "${executionStatus}" == *"Completed"* ]] || [[ "${executionStatus}" == "Error" ]] || [[ "${executionStatus}" == "Cancelled" ]] ) then
+if ( [[ "${executionStatus}" == *"Completed"* ]] then
   log "INF" "Execution with id \"${executionId}\" finished."
   
   # Fetch results when execution is finished
@@ -731,6 +731,9 @@ if ( [[ "${executionStatus}" == *"Completed"* ]] || [[ "${executionStatus}" == "
   writeResults "false"
   log "INF" "Stopping ToscaExecutionClient..."
   exit 0
+elif ( [[ "${executionStatus}" == "Error" ]] || [[ "${executionStatus}" == "Cancelled" ]] ) then
+  log "ERR" "Execution Error or Cancelled!"
+  exit 1
 else
   log "ERR" "Execution exceeded clientTimeout of ${clientTimeout} seconds. Stopping ToscaExecutionClient..."
   exit 1


### PR DESCRIPTION
The exit code it is very important when there is an integration with Jenkins.  With the previous code, a Jenkins pipeline that integrate tosca_execution_client.sh will never fail even if executionStatus is Error.