### PR TITLE
Change $logFileName to include milliseconds.

### DIFF
--- a/tosca_execution_client.ps1
+++ b/tosca_execution_client.ps1
@@ -53,6 +53,9 @@ param(
 [string]$executionStatus=""
 [string]$executionResults=""
 
+# Define logFileName
+$logFileName = "$(Get-Date -Format "yyyyMMddssfff")_ToscaExecutionClient.txt"
+
 ######################################################################
 # Functions
 ######################################################################
@@ -119,7 +122,6 @@ function log([string]$logLevel, [string]$logMessage) {
         }
     }
 
-    $logFileName = "$(Get-Date -Format "yyyyMMdd")_ToscaExecutionClient.txt"
     $logFilePath = "$logFolderPath\$logFileName"
 
     try {        


### PR DESCRIPTION
This fixes a bug where multiple parallel runs of the powershell client would abort because the log file is already locked.
- Move $logFileName definition to global context
- Add seconds and milliseconds to $logFileName