### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@ Our Tosca Execution Clients allow you to trigger Tosca TestEvents from CI/CD pip
 Tosca Execution Clients leverage the Execution API of Tosca Server. If you want to integrate directly with the Execution API, check out our online help.
 
 ## Supported functionality
-### Tosca 15.2
 Tosca Execution Client supports full functionality for DEX executions. For Elastic Execution Grid executions, Tosca Execution Client supports enqueuing executions through the enqueueOnly option.
-
-### Tosca 16.0 Technical Preview
-Tosca Execution Client supports full functionality for DEX executions. For Elastic Execution Grid executions, Tosca Execution Client supports full functionality, except overwriting test configuration parameters.
 
 ## System requirements
 To use Tosca Execution Clients, you need Tosca Server 15.2 LTS or higher. We offer the client in two versions: for Windows systems and Linux systems.
@@ -74,6 +70,7 @@ Check out the [Tosca help](https://support.tricentis.com/community/manuals_detai
 | creator               | Name of who triggered the execution. The DEX Monitor UI displays this name (default: ToscaExecutionClient).
 | d, debug              | Activate debug mode.
 | enqueueOnly           | Only enqueue the execution. Tosca Execution Client doesn't fetch results.
+| enqueueOnlyWithStatus | Enqueue the execution and continue polling. ToscaExecutionClient doesn't fetch results.
 | executionEnvironment  | Environment in which you want to execute the event. Possible values are "Dex" or "ElasticExecutionGrid" (default: "Dex").
 | executionId           | ID of the execution for which you want to get results. You only need this parameter if you choose "fetchResultsOnly".
 | fetchPartialResults   | Fetch partial execution results.
@@ -82,7 +79,7 @@ Check out the [Tosca help](https://support.tricentis.com/community/manuals_detai
 | importResults         | Import results into your Tosca project. Possible values are "true" and "false".
 | insecure              | Disables peer certificate validation when you use HTTPS. You can use this parameter only with Tosca Execution Client for Linux.
 | logFolderPath         | Path to the folder where the Tosca Execution Client saves log files (default: logs).
-| pollingInterval       | Interval in seconds in which the Tosca Execution Client requests results from the DEX Server (default: 60).
+| pollingInterval       | Interval in seconds in which the Tosca Execution Client requests results from the DEX Server (default: 120).
 | requestTimeout        | Time in seconds that the Tosca Execution Client waits for a response from AOS (default: 180).
 | requestRetries        | Number of times that Tosca Execution Client retries failed requests (default: 5). You can use this parameter only with Tosca Execution Client for Linux.
 | requestRetryDelay     | Time in seconds that Tosca Execution Client waits until it retries a failed request (default: 30). You can use this parameter only with Tosca Execution Client for Linux.

--- a/tosca_execution_client.ps1
+++ b/tosca_execution_client.ps1
@@ -29,12 +29,13 @@ param(
     [Alias("h")]
     [switch]$help,
     [switch]$enqueueOnly,
+    [switch]$enqueueOnlyWithStatus,
     [string]$executionId = "",
     [string]$importResults = "true",
     [switch]$fetchPartialResults,
     [switch]$fetchResultsOnly,
     [string]$logFolderPath = "logs",
-    [int]$pollingInterval = 60,
+    [int]$pollingInterval = 120,
     [int]$requestTimeout = 180,
     [string]$resultsFileName = "",
     [string]$resultsFolderPath = "results",
@@ -82,6 +83,7 @@ function displayHelp() {
     Write-Output " creator                   Name of who triggered the execution. The DEX Monitor UI displays this name (default: ToscaExecutionClient)."
     Write-Output " debug                     Activates debug mode."
     Write-Output " enqueueOnly               Only enqueue the execution. ToscaExecutionClient doesn't fetch results."
+    Write-Output " enqueueOnlyWithStatus     Enqueue the execution and continue polling. ToscaExecutionClient doesn't fetch results." 
     Write-Output " executionEnvironment      Environment in which you want to execute the event. Possible values are ""Dex"" or ""ElasticExecutionGrid"" (default: ""Dex"")."
     Write-Output " executionId               ID of the execution for which you want to get results. You only need this parameter if you choose ""fetchResultsOnly""."
     Write-Output " fetchPartialResults       Fetch partial execution results."
@@ -89,7 +91,7 @@ function displayHelp() {
     Write-Output " help                      Get usage information for the ToscaExecutionClient."
     Write-Output " importResults             Import results into your Tosca project. Possible values are ""true"" and ""false""."
     Write-Output " logFolderPath             Path to the folder where the ToscaExecutionClient saves log files (default: logs)."
-    Write-Output " pollingInterval           Interval in seconds in which the ToscaExecutionClient requests results from the DEX Server (default: 60)."
+    Write-Output " pollingInterval           Interval in seconds in which the ToscaExecutionClient requests results from the DEX Server (default: 120)."
     Write-Output " resultsFileName           Name of the file in which ToscaExecutionClient saves execution results (default: ""<executionId>_results.xml"")."
     Write-Output " requestTimeout            Time in seconds that the ToscaExecutionClient waits for a response from AOS (default: 180)."
     Write-Output " resultsFolderPath         Path to the folder where ToscaExecutionClient saves execution results (default: results)."
@@ -604,6 +606,21 @@ if ( $fetchResultsOnly -eq $true ) {
         log "INF" "Stopping ToscaExecutionClient..."
         exit 0
     }
+
+    # Skip fetching of execution results when enqueueOnlyWithStatusOption is given
+    if ($enqueueOnlyWithStatus -eq $true) {
+    log "INF" "enqueueOnlyWithStatus activated: Polling will continue, but results will not be fetched."
+    $keepPolling = $true
+    while ($keepPolling -eq $true) {
+        $executionStatus = Get-ExecutionStatus -toscaServerUrl $toscaServerUrl -projectName $projectName
+        log "DBG" "Current execution status: $executionStatus"
+        $keepPolling = ($(getTimestamp) -le $executionTimeout) -and -not ($executionStatus -like "*Completed*") -and -not ($executionStatus -eq "Error") -and -not ($executionStatus -eq "Cancelled")
+        if ($keepPolling -eq $false) { break }
+        Start-Sleep -Seconds $pollingInterval
+    }
+    log "INF" "Polling completed for enqueueOnlyWithStatus. Exiting without fetching results."
+    return
+}
 }
 
 # Handle missing execution id


### PR DESCRIPTION
This update introduces a new functionality to the script: the enqueueOnlyWithStatus option. This enhancement builds upon the existing enqueueOnly parameter by adding a distinct behavior, allowing users to poll the execution status of tests without retrieving the final results.