### PR TITLE
Strip trailing "/" from Tosca Server Url if provided 

### DIFF
--- a/tosca_execution_client.ps1
+++ b/tosca_execution_client.ps1
@@ -567,6 +567,11 @@ if ( [String]::IsNullOrEmpty($toscaServerUrl) ) {
     $validationFailed = $false
 }
 
+# If the toscaServerUrl contains and trailing slash remove it, as this breaks API calls
+if ($toscaServerUrl -match "/$") {
+	$toscaServerUrl = $toscaServerUrl.Substring(0, $toscaServerUrl.Length - 1)
+}
+
 # Print help and exit if validation failed
 if ( $validationFailed -eq $true ) {
     displayHelp

--- a/tosca_execution_client.sh
+++ b/tosca_execution_client.sh
@@ -634,6 +634,11 @@ else
   validationFailed=false
 fi
 
+# Strip trailing / from url as this causes Tosca Server APIs to Error
+if [[ ${toscaServerUrl} =~ /$ ]]; then
+	toscaServerUrl="${toscaServerUrl%/}"
+fi
+
 # Skip enqueue call if fetchResultsOnlyOption is given
 if ( [ "${validationFailed}" == "true" ] ) then
   displayHelp


### PR DESCRIPTION
Tosca Server fails with  as an input causes the API to fail with a 404 from the Gateway Service as it cannot find the right service to handle the API calls. 

Users that copy a URL for their server from their browser can include the trailing slash. 