### PR TITLE
fix: prevent empty results when statis is 206

### DIFF
--- a/tosca_execution_client.ps1
+++ b/tosca_execution_client.ps1
@@ -521,7 +521,7 @@ function fetchExecutionResults ([bool]$fetchPartialResults = $false) {
         # Not all results are available (E.g. cancelled events, configuration errors) 
         elseif ( $status -eq 206 ) {
             log "WRN" "Not all execution results have been returned for execution with id ""$executionId"". Check AOS, DEX Server and DEX agent logs."
-            $script:executionResults="$responseBody"
+            $script:executionResults=$content
         }
         # Handle non existing results when fetchPartialResults option is activated
         elseif ( $fetchPartialResults -eq $true ) {


### PR DESCRIPTION
set proper content for the execution results when response status code is 206